### PR TITLE
Escape brackets in c_defs

### DIFF
--- a/CubeMX2Makefile.py
+++ b/CubeMX2Makefile.py
@@ -150,7 +150,7 @@ nodes = root.findall('.//tool[@superClass="com.atollic.truestudio.exe.debug.tool
 for node in nodes:
     value = node.attrib.get('value')
     if (value != ""):
-        c_defs += ' -D' + value
+        c_defs += ' -D' + re.sub(r'([()])', r'\\\1', value)
 
 # Link script
 memory = ''


### PR DESCRIPTION
Escape brackets in c_defs to bypass the error:

```
arm-none-eabi-gcc -c -mthumb -mcpu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=softfp -D__weak=__attribute__((weak)) -D__packed=__attribute__((__packed__)) -DUSE_HAL_DRIVER -DSTM32F401xE -IInc -IDrivers/STM32F4xx_HAL_Driver/Inc -IDrivers/STM32F4xx_HAL_Driver/Inc/Legacy -IDrivers/CMSIS/Include -IDrivers/CMSIS/Device/ST/STM32F4xx/Include -O0 -Wall -fdata-sections -ffunction-sections -g -gdwarf-2 -MD -MP -MF .dep/system_stm32f4xx.o.d -Wa,-a,-ad,-alms=build/system_stm32f4xx.lst Drivers/CMSIS/Device/ST/STM32F4xx/Source/Templates/system_stm32f4xx.c -o build/system_stm32f4xx.o
/bin/sh: -c: line 0: syntax error near unexpected token `('
/bin/sh: -c: line 0: `arm-none-eabi-gcc -c -mthumb -mcpu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=softfp -D__weak=__attribute__((weak)) -D__packed=__attribute__((__packed__)) -DUSE_HAL_DRIVER -DSTM32F401xE -IInc -IDrivers/STM32F4xx_HAL_Driver/Inc -IDrivers/STM32F4xx_HAL_Driver/Inc/Legacy -IDrivers/CMSIS/Include -IDrivers/CMSIS/Device/ST/STM32F4xx/Include -O0 -Wall -fdata-sections -ffunction-sections -g -gdwarf-2 -MD -MP -MF .dep/system_stm32f4xx.o.d -Wa,-a,-ad,-alms=build/system_stm32f4xx.lst Drivers/CMSIS/Device/ST/STM32F4xx/Source/Templates/system_stm32f4xx.c -o build/system_stm32f4xx.o'
Makefile:107: recipe for target 'build/system_stm32f4xx.o' failed
make: *** [build/system_stm32f4xx.o] Error 1
```
