### PR TITLE
Considered the problem with "link script"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+
+STM32CUBEMX_PATH=/usr/local/STMicroelectronics/STM32Cube/STM32CubeMX/STM32CubeMX.exe
+
+all: project_toolchains_dirs makefile
+
+project_toolchains_dirs:
+	java -jar $(STM32CUBEMX_PATH) -q project_toolchains_dirs.cubemx $(PWD)/*.ioc
+	cp "$(wildcard $(PWD)/SW4STM32/*/*.ld)" "$(wildcard $(PWD)/TrueSTUDIO/*/*.ld)"
+
+makefile:
+	python CubeMX2Makefile.py "$(PWD)"
+

--- a/project_toolchains_dirs.cubemx
+++ b/project_toolchains_dirs.cubemx
@@ -1,0 +1,5 @@
+project toolchain SW4STM32
+project generate
+project toolchain TrueSTUDIO
+project generate
+exit

--- a/readme.md
+++ b/readme.md
@@ -5,3 +5,19 @@ This program generates a Makefile from STM32CubeMX (http://www.st.com/stm32cube)
 Copyright (c) 2015, Baoshi Zhu. All rights reserved.
 
 Source code in this project is governed by Apache License 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+
+# Usage
+
+
+## Way 1
+
+* Generate code in STM32CubeMX for TrueSTUDIO toolchain.
+* Run `python /path/to/CubeMX2Makefile/CubeMX2Makefile.py path_to_project`.
+
+If there will be an error with "link script" then generate code for "SW4STM32" toolchain and copy `SW4STM32/*/*.ld` to `TrueSTUDIO/*/*.ld`.
+
+## Way 2
+
+* Enter to the directory of the project.
+* Run `make -C /path/to/CubeMX2Makefile`
+


### PR DESCRIPTION
By unknown reason on Debian the recent STM32CubeMX generates code with empty "link script" in "TrueSTUDIO/". So it's required to generate the code also for "SW4STM32" and replace TrueSTUDIO's "*.ld" with the one of SW4STM32. So I added a Makefile that does it automatically. See updates in `readme.md`.

Related: https://github.com/baoshi/CubeMX2Makefile/issues/3
