### PR TITLE
explicitly create build directory

### DIFF
--- a/CubeMX2Makefile.tpl
+++ b/CubeMX2Makefile.tpl
@@ -67,7 +67,7 @@ LIBDIR =
 LDFLAGS = $LDMCU -specs=nano.specs -T$$(LDSCRIPT) $$(LIBDIR) $$(LIBS) -Wl,-Map=$$(BUILD_DIR)/$$(TARGET).map,--cref -Wl,--gc-sections
 
 # default action: build all
-all: $$(BUILD_DIR)/$$(TARGET).elf $$(BUILD_DIR)/$$(TARGET).hex $$(BUILD_DIR)/$$(TARGET).bin
+all: $$(BUILD_DIR) $$(BUILD_DIR)/$$(TARGET).elf $$(BUILD_DIR)/$$(TARGET).hex $$(BUILD_DIR)/$$(TARGET).bin
 
 #######################################
 # build the application


### PR DESCRIPTION
The command "make all" in ubuntu 16.04 was giving me a hard time, so I investigated and found the build folder wasn't being created. My proposed fix is to add explicitly the dependency, so it first creates the directory, and after that it makes all the other steps.
